### PR TITLE
Initialize name and current_turn when a game is created

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -27,6 +27,8 @@ class GamesController < ApplicationController
     @game = Game.new(game_params)
     @game.current_turn = 0
     @game.save
+    @game.name = "Game #{@game.id}"
+    @game.save
 
     respond_to do |format|
       if @game.save

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -32,7 +32,6 @@ class GamesController < ApplicationController
   def create
     @game = Game.new(game_params)
     @game.current_turn = 0
-    @game.save
 
     respond_to do |format|
       if @game.save

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,6 +1,12 @@
 class GamesController < ApplicationController
   before_action :set_game, only: [:show, :edit, :update, :destroy]
 
+  attr_accessor :name
+
+  def name
+    "Game #{self.id}"
+  end
+
   # GET /games
   # GET /games.json
   def index
@@ -26,8 +32,6 @@ class GamesController < ApplicationController
   def create
     @game = Game.new(game_params)
     @game.current_turn = 0
-    @game.save
-    @game.name = "Game #{@game.id}"
     @game.save
 
     respond_to do |format|

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -72,6 +72,6 @@ class GamesController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def game_params
-      params.require(:game).permit(:name)
+      params.require(:game).permit(:current_turn)
     end
 end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -25,6 +25,8 @@ class GamesController < ApplicationController
   # POST /games.json
   def create
     @game = Game.new(game_params)
+    @game.current_turn = 0
+    @game.save
 
     respond_to do |format|
       if @game.save

--- a/spec/controllers/games_controller_spec.rb
+++ b/spec/controllers/games_controller_spec.rb
@@ -19,13 +19,13 @@ RSpec.describe GamesController, type: :controller do
   describe "games#create action" do
     it "should create a new game in the database" do
       count = Game.count
-      post :create, game: { name: 'Chess!' }
+      post :create, game: { current_turn: 0 }
       expect(Game.count).to eq(count + 1)
     end
 
     it "should create a new game in the database if in json format" do
       count = Game.count
-      post :create, format: :json, game: { name: 'Chess!' }
+      post :create, format: :json, game: { current_turn: 0 }
       expect(Game.count).to eq(count + 1)
     end
   end
@@ -41,16 +41,16 @@ RSpec.describe GamesController, type: :controller do
   describe "games#update action" do
     it "should update a game in the database" do
       game = FactoryGirl.create(:game)
-      patch :update, id: game.id, game: { name: 'Chess!!' }
+      patch :update, id: game.id, game: { current_turn: 1 }
       game.reload
-      expect(game.name).to eq('Chess!!')
+      expect(game.current_turn).to eq(1)
     end
 
     it "should update a game in the database if in json format" do
       game = FactoryGirl.create(:game)
-      patch :update, id: game.id, format: :json, game: { name: 'Chess!!' }
+      patch :update, id: game.id, format: :json, game: { current_turn: 1 }
       game.reload
-      expect(game.name).to eq('Chess!!')
+      expect(game.current_turn).to eq(1)
     end
   end
 

--- a/spec/controllers/games_controller_spec.rb
+++ b/spec/controllers/games_controller_spec.rb
@@ -18,15 +18,15 @@ RSpec.describe GamesController, type: :controller do
 
   describe "games#create action" do
     it "should create a new game in the database" do
-      post :create, game: { name: 'Chess!'}
-      game = Game.last
-      expect(game.name).to eq("Chess!")
+      count = Game.count
+      post :create, game: { name: 'Chess!' }
+      expect(Game.count).to eq(count + 1)
     end
 
     it "should create a new game in the database if in json format" do
+      count = Game.count
       post :create, format: :json, game: { name: 'Chess!' }
-      game = Game.last
-      expect(game.name).to eq('Chess!')
+      expect(Game.count).to eq(count + 1)
     end
   end
 

--- a/spec/controllers/games_controller_spec.rb
+++ b/spec/controllers/games_controller_spec.rb
@@ -18,9 +18,9 @@ RSpec.describe GamesController, type: :controller do
 
   describe "games#create action" do
     it "should create a new game in the database" do
-      post :create, game: { name: 'Chess!' }
+      post :create, game: { name: 'Chess!'}
       game = Game.last
-      expect(game.name).to eq('Chess!')
+      expect(game.name).to eq("Chess!")
     end
 
     it "should create a new game in the database if in json format" do


### PR DESCRIPTION
Updated create action to initialize current_turn as 0 and the game name as "Game #{id}." Adjusted tests for the create action to rely on the game count rather than the auto-generated name.

Once we integrate devise and find a way to intake the opposing player, we can also update the create action randomly assign the players black and white.